### PR TITLE
Sushiswap adapter for ldo, spell, angle

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 
 import "./interfaces/IWrappedEther.sol";
 import "./interfaces/IExchangeAdapter.sol";
-
+import "hardhat/console.sol";
 contract Exchange is ReentrancyGuard, AccessControl {
     using SafeERC20 for IERC20;
     using Address for address;
@@ -81,7 +81,6 @@ contract Exchange is ReentrancyGuard, AccessControl {
         uint256 minAmountOut
     ) external payable nonReentrant returns (uint256) {
         require(from != to, "Exchange: from == to");
-
         if (lpTokens[to].swapProtocol != 0) {
             IERC20(from).safeTransferFrom(msg.sender, address(this), amountIn);
 
@@ -145,7 +144,6 @@ contract Exchange is ReentrancyGuard, AccessControl {
         uint256 amountOut_ = _exchange(from, to, amountIn);
 
         require(amountOut_ >= minAmountOut, "Exchange: slippage");
-
         IERC20(to).safeTransfer(msg.sender, amountOut_);
 
         return amountOut_;

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 
 import "./interfaces/IWrappedEther.sol";
 import "./interfaces/IExchangeAdapter.sol";
-import "hardhat/console.sol";
+
 contract Exchange is ReentrancyGuard, AccessControl {
     using SafeERC20 for IERC20;
     using Address for address;
@@ -81,6 +81,7 @@ contract Exchange is ReentrancyGuard, AccessControl {
         uint256 minAmountOut
     ) external payable nonReentrant returns (uint256) {
         require(from != to, "Exchange: from == to");
+
         if (lpTokens[to].swapProtocol != 0) {
             IERC20(from).safeTransferFrom(msg.sender, address(this), amountIn);
 
@@ -144,6 +145,7 @@ contract Exchange is ReentrancyGuard, AccessControl {
         uint256 amountOut_ = _exchange(from, to, amountIn);
 
         require(amountOut_ >= minAmountOut, "Exchange: slippage");
+
         IERC20(to).safeTransfer(msg.sender, amountOut_);
 
         return amountOut_;

--- a/contracts/adapters/SushiswapAdapter.sol
+++ b/contracts/adapters/SushiswapAdapter.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.14;
+import "@openzeppelin/contracts/interfaces/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "../interfaces/IExchange.sol";
+
+interface IUniswapV2Pair {
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function name() external pure returns (string memory);
+
+    function symbol() external pure returns (string memory);
+
+    function decimals() external pure returns (uint8);
+
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address owner) external view returns (uint256);
+
+    function allowance(address owner, address spender)
+        external
+        view
+        returns (uint256);
+
+    function approve(address spender, uint256 value) external returns (bool);
+
+    function transfer(address to, uint256 value) external returns (bool);
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) external returns (bool);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+    function PERMIT_TYPEHASH() external pure returns (bytes32);
+
+    function nonces(address owner) external view returns (uint256);
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+    event Burn(
+        address indexed sender,
+        uint256 amount0,
+        uint256 amount1,
+        address indexed to
+    );
+    event Swap(
+        address indexed sender,
+        uint256 amount0In,
+        uint256 amount1In,
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address indexed to
+    );
+    event Sync(uint112 reserve0, uint112 reserve1);
+
+    function MINIMUM_LIQUIDITY() external pure returns (uint256);
+
+    function factory() external view returns (address);
+
+    function token0() external view returns (address);
+
+    function token1() external view returns (address);
+
+    function getReserves()
+        external
+        view
+        returns (
+            uint112 reserve0,
+            uint112 reserve1,
+            uint32 blockTimestampLast
+        );
+
+    function price0CumulativeLast() external view returns (uint256);
+
+    function price1CumulativeLast() external view returns (uint256);
+
+    function kLast() external view returns (uint256);
+
+    function mint(address to) external returns (uint256 liquidity);
+
+    function burn(address to)
+        external
+        returns (uint256 amount0, uint256 amount1);
+
+    function swap(
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address to,
+        bytes calldata data
+    ) external;
+
+    function skim(address to) external;
+
+    function sync() external;
+
+    function initialize(address, address) external;
+}
+
+interface IExchangeAdapter {
+    // 0x6012856e  =>  executeSwap(address,address,address,uint256)
+    function executeSwap(
+        address pool,
+        address fromToken,
+        address toToken,
+        uint256 amount
+    ) external payable returns (uint256);
+
+    // 0x73ec962e  =>  enterPool(address,address,uint256)
+    function enterPool(
+        address pool,
+        address fromToken,
+        uint256 amount
+    ) external payable returns (uint256);
+
+    // 0x660cb8d4  =>  exitPool(address,address,uint256)
+    function exitPool(
+        address pool,
+        address toToken,
+        uint256 amount
+    ) external payable returns (uint256);
+}
+
+contract SushiswapAdapter is IExchangeAdapter {
+    using SafeERC20 for IERC20;
+    address constant exchange = address(0);
+
+    function executeSwap(
+        address pool,
+        address fromToken,
+        address toToken,
+        uint256 amount
+    ) external payable returns (uint256) {
+        IERC20(fromToken).transfer(pool, amount);
+        address token0 = IUniswapV2Pair(pool).token0();
+        (uint256 reserve0, uint256 reserve1, ) = IUniswapV2Pair(pool)
+            .getReserves();
+        (uint256 reserveIn, uint256 reserveOut) = fromToken == token0
+            ? (reserve0, reserve1)
+            : (reserve1, reserve0);
+        uint256 amountOut = getAmountOut(amount, reserveIn, reserveOut);
+        (uint256 amount0Out, uint256 amount1Out) = fromToken == token0
+            ? (uint256(0), amountOut)
+            : (amountOut, uint256(0));
+
+        IUniswapV2Pair(pool).swap(
+            amount0Out,
+            amount1Out,
+            msg.sender,
+            new bytes(0)
+        );
+        return toToken == token0 ? amount0Out : amount1Out;
+    }
+
+    function enterPool(
+        address pool,
+        address fromToken,
+        uint256 amount
+    ) external payable returns (uint256) {
+        IERC20(fromToken).transfer(pool, amount);
+        return IUniswapV2Pair(pool).mint(msg.sender);
+    }
+
+    // Amount = amount of lptokens to burn!
+    function exitPool(
+        address pool,
+        address toToken,
+        uint256 amount
+    ) external payable returns (uint256) {
+        IUniswapV2Pair(pool).transfer(pool, amount);
+        (uint256 amount0, uint256 amount1) = IUniswapV2Pair(pool).burn(
+            msg.sender
+        );
+        address token0 = IUniswapV2Pair(pool).token0();
+        address token1 = IUniswapV2Pair(pool).token1();
+        // Uniswap returns in 'equal' value amounts.
+        // We need to exchange these tokens again to the toToken using the exchange
+        if (token1 == toToken) {
+            return
+                IExchange(exchange).exchange(token0, toToken, amount0, 0) +
+                amount1;
+        } else {
+            return
+                IExchange(exchange).exchange(token1, toToken, amount1, 0) +
+                amount0;
+        }
+    }
+
+    // given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
+    function getAmountOut(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) internal pure returns (uint256 amountOut) {
+        require(amountIn > 0, "UniswapV2Library: INSUFFICIENT_INPUT_AMOUNT");
+        require(
+            reserveIn > 0 && reserveOut > 0,
+            "UniswapV2Library: INSUFFICIENT_LIQUIDITY"
+        );
+        uint256 amountInWithFee = amountIn * 997;
+        uint256 numerator = amountInWithFee * reserveOut;
+        uint256 denominator = reserveIn * 1000 + amountInWithFee;
+        amountOut = numerator / denominator;
+    }
+}

--- a/contracts/adapters/SushiswapAdapter.sol
+++ b/contracts/adapters/SushiswapAdapter.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.11;
 import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../interfaces/IExchange.sol";
+import "hardhat/console.sol";
 
 interface IUniswapV2Pair {
     event Approval(
@@ -139,7 +140,7 @@ interface IExchangeAdapter {
 
 contract SushiswapAdapter is IExchangeAdapter {
     using SafeERC20 for IERC20;
-    address constant exchange = address(0);
+    address constant exchange = 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7;
 
     function executeSwap(
         address pool,
@@ -158,11 +159,10 @@ contract SushiswapAdapter is IExchangeAdapter {
         (uint256 amount0Out, uint256 amount1Out) = fromToken == token0
             ? (uint256(0), amountOut)
             : (amountOut, uint256(0));
-
         IUniswapV2Pair(pool).swap(
             amount0Out,
             amount1Out,
-            msg.sender,
+            address(this),
             new bytes(0)
         );
         return toToken == token0 ? amount0Out : amount1Out;
@@ -173,8 +173,7 @@ contract SushiswapAdapter is IExchangeAdapter {
         address fromToken,
         uint256 amount
     ) external payable returns (uint256) {
-        IERC20(fromToken).transfer(pool, amount);
-        return IUniswapV2Pair(pool).mint(msg.sender);
+        revert("SushiswapAdapter: cant enter");
     }
 
     // Amount = amount of lptokens to burn!
@@ -183,23 +182,8 @@ contract SushiswapAdapter is IExchangeAdapter {
         address toToken,
         uint256 amount
     ) external payable returns (uint256) {
-        IUniswapV2Pair(pool).transfer(pool, amount);
-        (uint256 amount0, uint256 amount1) = IUniswapV2Pair(pool).burn(
-            msg.sender
-        );
-        address token0 = IUniswapV2Pair(pool).token0();
-        address token1 = IUniswapV2Pair(pool).token1();
-        // Uniswap returns in 'equal' value amounts.
-        // We need to exchange these tokens again to the toToken using the exchange
-        if (token1 == toToken) {
-            return
-                IExchange(exchange).exchange(token0, toToken, amount0, 0) +
-                amount1;
-        } else {
-            return
-                IExchange(exchange).exchange(token1, toToken, amount1, 0) +
-                amount0;
-        }
+        revert("SushiswapAdapter: cant enter");
+
     }
 
     // given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
@@ -218,4 +202,6 @@ contract SushiswapAdapter is IExchangeAdapter {
         uint256 denominator = reserveIn * 1000 + amountInWithFee;
         amountOut = numerator / denominator;
     }
+
+
 }

--- a/contracts/interfaces/IExchange.sol
+++ b/contracts/interfaces/IExchange.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.11;
+
+interface IExchange {
+    struct RouteEdge {
+        uint32 swapProtocol; // 0 - unknown edge, 1 - UniswapV2, 2 - Curve...
+        address pool; // address of pool to call
+        address fromCoin; // address of coin to deposit to pool
+        address toCoin; // address of coin to get from pool
+    }
+
+    function exchange(
+        address from,
+        address to,
+        uint256 amountIn,
+        uint256 minAmountOut
+    ) external payable returns (uint256);
+
+    function buildRoute(address from, address to)
+        external
+        view
+        returns (RouteEdge[] memory);
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,22 +13,13 @@ dotenv.config();
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.14",
+    version: "0.8.11",
     settings: {
       optimizer: {
         enabled: true,
         runs: 1000000,
       },
     },
-    compilers: [
-      {
-        version: "0.8.11"
-      },
-
-      {
-        version: "0.6.12"
-      }
-    ]
   },
   networks: {
     hardhat: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,13 +13,22 @@ dotenv.config();
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.11",
+    version: "0.8.14",
     settings: {
       optimizer: {
         enabled: true,
         runs: 1000000,
       },
     },
+    compilers: [
+      {
+        version: "0.8.11"
+      },
+
+      {
+        version: "0.6.12"
+      }
+    ]
   },
   networks: {
     hardhat: {

--- a/test/exchangeFullOps.ts
+++ b/test/exchangeFullOps.ts
@@ -22,11 +22,10 @@ describe("Exchange (full setup operations)", async () => {
     let wethUsdtRoute: Route, wethUsdcRoute: Route, wethDaiRoute: Route, usdtWethRoute: Route, usdtUsdcRoute: Route, usdtDaiRoute: Route,
         usdcWethRoute: Route, usdcUsdtRoute: Route, usdcDaiRoute: Route, daiUsdcRoute: Route, daiUsdtRoute: Route, daiWethRoute: Route,
         wethFraxRoute: Route, usdtFraxRoute: Route, daiFraxRoute: Route, usdcFraxRoute: Route, fraxUsdcRoute: Route, fraxDaiRoute: Route,
-        fraxUsdtRoute: Route, fraxWethRoute: Route , ldoWethRoute: Route,  spellWethRoute: Route, angleWethRoute : Route, wethLdoRoute: Route,  wethSpellRoute: Route, wethAngleRoute : Route;
+        fraxUsdtRoute: Route, fraxWethRoute: Route;
 
     let threeCrvEdge: Edge, cvxEdge: Edge, crvEdge: Edge, ustEdge: Edge, alluoEdge: Edge, rethEdge: Edge, angleEdge :Edge, ldoEdge : Edge, spellEdge: Edge;
 
-    let spellWhale : SignerWithAddress, ldoWhale : SignerWithAddress, angleWhale: SignerWithAddress
     const renbtcAddress = "0xD51a44d3FaE010294C616388b506AcdA1bfAAE46";
     const fraxPoolAddress = "0xd632f22692FaC7611d2AA1C0D552930D43CAEd3B";
     const threeCrvPool = "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7";
@@ -59,25 +58,6 @@ describe("Exchange (full setup operations)", async () => {
     }
 
     function initializeRoutes() {
-        ldoWethRoute = [
-            { swapProtocol: 10, pool: ldoWethPair, fromCoin: ldo.address, toCoin: weth.address }
-        ];
-        angleWethRoute = [
-            { swapProtocol: 10, pool: angleWethPair, fromCoin: angle.address, toCoin: weth.address}
-        ];
-        spellWethRoute = [
-            { swapProtocol: 10, pool: spellWethPair, fromCoin: spell.address, toCoin: weth.address }
-        ];
-        wethLdoRoute = [
-            { swapProtocol: 10, pool: ldoWethPair, fromCoin: weth.address, toCoin: ldo.address }
-        ];
-        wethAngleRoute = [
-            { swapProtocol: 10, pool: angleWethPair, fromCoin: weth.address, toCoin: angle.address}
-        ];
-        wethSpellRoute = [
-            { swapProtocol: 10, pool: spellWethPair, fromCoin: weth.address, toCoin: spell.address }
-        ];
-
         wethUsdtRoute = [
             { swapProtocol: 2, pool: renbtcAddress, fromCoin: weth.address, toCoin: usdt.address }
         ];
@@ -181,15 +161,11 @@ describe("Exchange (full setup operations)", async () => {
         exchange = await Exchange.deploy(dai.address, true);
         await exchange.deployed();
 
-        spellWhale = await getImpersonatedSigner(spellWhaleAddress);
-        ldoWhale = await getImpersonatedSigner(ldoWhaleAddress);
-        angleWhale = await getImpersonatedSigner(angleWhaleAddress);
-
         const routes: Route[] = [
             wethUsdtRoute, wethUsdcRoute, wethDaiRoute, usdtWethRoute, usdtUsdcRoute, usdtDaiRoute,
             usdcWethRoute, usdcUsdtRoute, usdcDaiRoute, daiUsdcRoute, daiUsdtRoute, daiWethRoute,
             wethFraxRoute, usdtFraxRoute, daiFraxRoute, usdcFraxRoute, fraxUsdcRoute, fraxDaiRoute,
-            fraxUsdtRoute, fraxWethRoute, //wethAngleRoute, wethSpellRoute, wethLdoRoute, angleWethRoute, spellWethRoute, ldoWethRoute
+            fraxUsdtRoute, fraxWethRoute,
         ];
 
         await (await exchange.createInternalMajorRoutes(routes)).wait();

--- a/test/tokenFetcher_test.ts
+++ b/test/tokenFetcher_test.ts
@@ -13,17 +13,17 @@ describe("Token Fetcher Tests", async () => {
 
 
   before(async () => {
-    const investorAddress = process.env.IMPERSONATE_ADDRESS as string;
+    const gnosisAddress = "0x1F020A4943EB57cd3b2213A66b355CB662Ea43C3"
 
     await ethers.provider.send(
       'hardhat_impersonateAccount',
-      [investorAddress]
+      [gnosisAddress]
     );
 
-    investor = await ethers.getSigner(investorAddress);
+    investor = await ethers.getSigner(gnosisAddress);
 
     const TokenFetcher = await ethers.getContractFactory("TokenFetcher");
-    tokenFetcher = await TokenFetcher.deploy(investorAddress, true);
+    tokenFetcher = await TokenFetcher.deploy(gnosisAddress, true);
   });
 
   it("Should Add Major Coins", async () => {


### PR DESCRIPTION
Hi, 

https://app.dework.xyz/alluo/alluo-smart-contra?taskId=597cbcd1-0dde-493d-a4ac-9151f1e3138f

https://app.dework.xyz/alluo/alluo-smart-contra?taskId=5c1865a4-d4e5-4cae-8b9c-03b5917a4cab

https://app.dework.xyz/alluo/alluo-smart-contra?taskId=16b861f8-52a0-4818-8276-4fb118ea6569

All 3 tasks with one adapter.

The adapter cannot enter and exit pool to get the LP tokens of the pools because of how uniswap  requires deposits in equal values to add liquidity.

The executeswap function carries out all the checks the uniswap router would do + calculates key values to enter pool safely.

I changed the tests to include all new tokens + all combos.

penta